### PR TITLE
Fix

### DIFF
--- a/src/philipshilling/alwaysspawn/Loader.php
+++ b/src/philipshilling/alwaysspawn/Loader.php
@@ -3,7 +3,7 @@
 namespace philipshilling\alwaysspawn;
 
 use pocketmine\event\Listener;
-use pocketmine\event\player\PlayerLoginEvent;
+use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\plugin\PluginBase as Plugin;
 
 class Loader extends Plugin implements Listener{
@@ -11,8 +11,7 @@ class Loader extends Plugin implements Listener{
 		$this->getServer()->getPluginManager()->registerEvents($this, $this);
 	}
 
-	public function onPlayerLogin(PlayerLoginEvent $event){
+	public function onPlayerJoin(PlayerJoinEvent $event){
 		$event->getPlayer()->teleport($this->getServer()->getWorldManager()->getDefaultWorld()->getSafeSpawn());
 	}
-
 }


### PR DESCRIPTION
Ensures the player always spawn at the spawn point. Sometimes when a player joins it doesn’t teleport them to the spawn point.